### PR TITLE
Fix issue with multiple spans in a heading

### DIFF
--- a/src/heartfelt_hooks/check_heading_levels.py
+++ b/src/heartfelt_hooks/check_heading_levels.py
@@ -139,10 +139,19 @@ class NotebookHeadings:
         for child in doc.children:
             if isinstance(child, mistletoe.block_token.Heading):
                 headings.append(
-                    Heading(level=child.level, text=child.children[0].content)
+                    Heading(level=child.level, text=_get_content(child))
                 )
 
         return headings
+
+
+def _get_content(token):
+    try:
+        child = token.children[0]
+    except (AttributeError, IndexError):
+        return token.content
+    else:
+        return _get_content(child)
 
 
 class NotebookHeadingValidator:

--- a/src/heartfelt_hooks/check_heading_levels.py
+++ b/src/heartfelt_hooks/check_heading_levels.py
@@ -138,9 +138,7 @@ class NotebookHeadings:
         headings = []
         for child in doc.children:
             if isinstance(child, mistletoe.block_token.Heading):
-                headings.append(
-                    Heading(level=child.level, text=_get_content(child))
-                )
+                headings.append(Heading(level=child.level, text=_get_content(child)))
 
         return headings
 


### PR DESCRIPTION
This pull request fixes an issue with getting the content of a heading that contains one or more span elements. For example:
```markdown
# ***Heading***
```
