### PR TITLE
Fix issue #10

### DIFF
--- a/src/heartfelt_hooks/check_heading_levels.py
+++ b/src/heartfelt_hooks/check_heading_levels.py
@@ -144,12 +144,10 @@ class NotebookHeadings:
 
 
 def _get_content(token):
-    try:
-        child = token.children[0]
-    except (AttributeError, IndexError):
-        return token.content
+    if hasattr(token, "children") and token.children:
+        return _get_content(token.children[0])
     else:
-        return _get_content(child)
+        return token.content
 
 
 class NotebookHeadingValidator:


### PR DESCRIPTION
This pull request fixes an error that cropped up with *mistletoe* v1.4 (#10). In previous versions, if a token didn't have any children, the `children` attribute would either be missing or be an empty list. In version 1.4, that attribute is always present and is set to `None` if there are no children. The changes in this pull request should be compatible with both 1.3 and 1.4.